### PR TITLE
Additional definitions and exceptions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -20,3 +20,15 @@ indent_style = tab
 
 [*.js]
 insert_final_newline = true
+
+[*.go]
+indent_style = tab
+indent_size = 8
+
+[{*.md,README}]
+trim_trailing_whitespace = false
+
+# Minified JavaScript files shouldn't be changed
+[**.min.js]
+indent_style = ignore
+insert_final_newline = ignore


### PR DESCRIPTION
- go: _should_ be using `go fmt` but same could be said for all this
- don't add trailing space for markdown-style files
- ignore minified js
